### PR TITLE
Fix Seurat, fix & reenable CELESTA

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,5 +1,5 @@
 # Base image with Java, R, and Python
-FROM rocker/r-ver:4.2.2
+FROM rocker/r-ver:4.4.1
 
 # Add the deadsnakes PPA to get Python 3.8
 RUN apt-get update && apt-get install -y software-properties-common && \
@@ -41,6 +41,7 @@ RUN R --quiet -e "install.packages(c('knitr', 'ggplot2', 'data.table', 'dplyr'))
 # If we remove the 1st Seurat install, the container fails.
 # If we remove the redundant installs for kableExtra, ComplexHeatmap, clustree, the container fails.
 # We aren't 100% sure why this is … but … this works, so we're keeping it.
+RUN R --quiet -e "install.packages('Matrix', repos = 'https://cloud.r-project.org', version='>= 1.6-4')"
 RUN R --quiet -e "install.packages('Seurat', repos = 'https://cloud.r-project.org')"
 RUN R --quiet -e "install.packages(c('progressr', 'kableExtra', 'ComplexHeatmap', 'ggridges', 'clustree', 'pheatmap', 'plyr'))"
 RUN R --quiet -e "install.packages(c('pander', 'CELESTA', 'Rmixmod'))"

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -12,8 +12,10 @@ RUN apt-get install -y \
     git \
     libcurl4-openssl-dev \
     libfontconfig1-dev \
+    libgdal-dev \
     libhdf5-serial-dev \
     libssl-dev \
+    libudunits2-dev \
     libxml2-dev \
     libxt-dev \
     openjdk-17-jdk \
@@ -56,15 +58,8 @@ RUN R --quiet -e "install.packages('clustree')"
 RUN R --quiet -e "install.packages('kableExtra')"
 RUN R --quiet -e "install.packages('Matrix')"
 
-
-##############################################################
-# CELESTA does not work–
-# Seems to succeed installing, BUT, CELESTA_clustering.Rmd fails ("celesta not found")
-# RUN apt-get install -y r-cran-devtools
-# RUN R --quiet -e "install.packages('devtools')"
-# RUN R --quiet -e "install.packages('remotes')"
-# RUN R --quiet -e "remotes::install_github('plevritis-lab/CELESTA')"
-##############################################################
+RUN R --quiet -e "install.packages('remotes')"
+RUN R --quiet -e "remotes::install_github('plevritis-lab/CELESTA')"
 
 # Cleanup to reduce image size
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
@@ -77,3 +72,4 @@ COPY modules/ /app/modules
 COPY scripts/ /app/scripts
 COPY main.nf /app/main.nf
 COPY nextflow.config /app/nextflow.config
+COPY celesta_prior_matrix.csv /app/celesta_prior_matrix.csv

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,7 +11,7 @@ params {
   // Run options
   qc_only = false
   run_scimap = true
-  run_celesta = false
+  run_celesta = true
   run_seurat = true
   export_intermediates = false
   

--- a/scripts/seurat_clustering.Rmd
+++ b/scripts/seurat_clustering.Rmd
@@ -469,9 +469,7 @@ clusters_out$roi <- roi
 fwrite(clusters_out, cluster_outfile)
 
 p1 <- DimPlot(codex.obj, label = T) + NoLegend()
-# FIXME: confirm that it's fine to remove flip_xy = FALSE
-# p2 <- ImageDimPlot(codex.obj, flip_xy = FALSE) + scale_x_reverse()
-p2 <- ImageDimPlot(codex.obj) + scale_x_reverse()
+p2 <- ImageDimPlot(codex.obj, flip_xy = FALSE) + scale_x_reverse()
 p1 + p2
 ```
 


### PR DESCRIPTION
Fix Seurat & CELESTA:

* Update to r-ver 4.4.1 (to support newer version of Matrix library required by Seurat)
* Add Celesta sample matrix to container.
* Restore `flip_xy` parameter now that we have proper Seurat dependencies.